### PR TITLE
Update registers-sungrow.yaml

### DIFF
--- a/SunGather/registers-sungrow.yaml
+++ b/SunGather/registers-sungrow.yaml
@@ -1,0 +1,2026 @@
+version:  0.2.4
+vendor: Sungrow
+registers:
+  - read:
+    - name: "protocol_number"
+      level: 2
+      address: 4950
+      datatype: "U32"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "protocol_version"
+      level: 2
+      address: 4952
+      datatype: "U32"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "arm_software_version"
+      level: 2
+      address: 4954
+      datatype: "U16"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "dsp_software_version"
+      level: 2
+      address: 4969
+      datatype: "U16"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "serial_number"
+      level: 3
+      address: 4990
+      datatype: "UTF-8"
+    - name: "device_type_code"
+      level: 3
+      address: 5000
+      datatype: "U16"
+      datarange:
+      # PV Grid-Connected String Inverters
+        - response: 0x27
+          value: "SG30KTL"
+        - response: 0x26
+          value: "SG10KTL"
+        - response: 0x29
+          value: "SG12KTL"
+        - response: 0x28
+          value: "SG15KTL"
+        - response: 0x2A
+          value: "SG20KTL"
+        - response: 0x2C
+          value: "SG30KU"
+        - response: 0x2D
+          value: "SG36KTL"
+        - response: 0x2E
+          value: "SG36KU"
+        - response: 0x2F
+          value: "SG40KTL"
+        - response: 0x0135
+          value: "SG40KTL-M"
+        - response: 0x011B
+          value: "SG50KTL-M"
+        - response: 0x0131
+          value: "SG60KTL-M"
+        - response: 0x0136
+          value: "SG60KU"
+        - response: 0x0141
+          value: "SG30KTL-M"
+        - response: 0x70
+          value: "SG30KTL-M-V31"
+        - response: 0x0134
+          value: "SG33KTL-M"
+        - response: 0x74
+          value: "SG36KTL-M"
+        - response: 0x013D
+          value: "SG33K3J"
+        - response: 0x0137
+          value: "SG49K5J"
+        - response: 0x72
+          value: "SG34KJ"
+        - response: 0x73
+          value: "LP_P34KSG"
+        - response: 0x011B
+          value: "SG50KTL-M-20"
+        - response: 0x010F
+          value: "SG60KTL"
+        - response: 0x0138
+          value: "SG80KTL"
+        - response: 0x0138
+          value: "SG80KTL-20"
+        - response: 0x0132
+          value: "SG60KU-M"
+        - response: 0x0147
+          value: "SG5KTL-MT"
+        - response: 0x0148
+          value: "SG6KTL-MT"
+        - response: 0x013F
+          value: "SG8KTL-M"
+        - response: 0x013E
+          value: "SG10KTL-M"
+        - response: 0x2C0F
+          value: "SG10KTL-MT"
+        - response: 0x013C
+          value: "SG12KTL-M"
+        - response: 0x0142
+          value: "SG15KTL-M"
+        - response: 0x0149
+          value: "SG17KTL-M"
+        - response: 0x0143
+          value: "SG20KTL-M"
+        - response: 0x0139
+          value: "SG80KTL-M"
+        - response: 0x014C
+          value: "SG111HV"
+        - response: 0x013B
+          value: "SG125HV"
+        - response: 0x2C03
+          value: "SG125HV-20"
+        - response: 0x2C10
+          value: "SG30CX"
+        - response: 0x2C00
+          value: "SG33CX"
+        - response: 0x2C0A
+          value: "SG36CX-US"
+        - response: 0x2C01
+          value: "SG40CX"
+        - response: 0x2C02
+          value: "SG50CX"
+        - response: 0x2C0B
+          value: "SG60CX-US"
+        - response: 0x2C06
+          value: "SG110CX"
+        - response: 0x2C0C
+          value: "SG250HX"
+        - response: 0x2C11
+          value: "SG250HX-US"
+        - response: 0x2C12
+          value: "SG100CX"
+        - response: 0x2C12
+          value: "SG100CX-JP"
+        - response: 0x2C13
+          value: "SG250HX-IN"
+        - response: 0x2C15
+          value: "SG25CX-SA"
+        - response: 0x2C22
+          value: "SG75CX"
+        - response: 0x243D
+          value: "SG3.0RT"
+        - response: 0x243E
+          value: "SG4.0RT"
+        - response: 0x2430
+          value: "SG5.0RT"
+        - response: 0x2431
+          value: "SG6.0RT"
+        - response: 0x243C
+          value: "SG7.0RT"
+        - response: 0x2432
+          value: "SG8.0RT"
+        - response: 0x2433
+          value: "SG10RT"
+        - response: 0x2434
+          value: "SG12RT"
+        - response: 0x2435
+          value: "SG15RT"
+        - response: 0x2436
+          value: "SG17RT"
+        - response: 0x2437
+          value: "SG20RT"
+      # Residential Hybrid Inverters
+        - response: 0xD09
+          value: "SH5K-20"
+        - response: 0xD06
+          value: "SH3K6"
+        - response: 0xD07
+          value: "SH4K6"
+        - response: 0xD03
+          value: "SH5K-V13"
+        - response: 0xD0C
+          value: "SH5K-30"
+        - response: 0xD0A
+          value: "SH3K6-30"
+        - response: 0xD0B
+          value: "SH4K6-30"
+        - response: 0xD0F
+          value: "SH5.0RS"
+        - response: 0xD0D
+          value: "SH3.6RS"
+        - response: 0xD0E
+          value: "SH4.6RS"
+        - response: 0xD10
+          value: "SH6.0RS"
+        - response: 0xE03
+          value: "SH10RT"
+        - response: 0xE0F
+          value: "SH10RT-V112"
+        - response: 0xE02
+          value: "SH8.0RT"
+        - response: 0xE01
+          value: "SH6.0RT"
+        - response: 0xE00
+          value: "SH5.0RT"
+        - response: 0xE0C
+          value: "SH5.0RT-V112"
+      # G2 Inverters
+        - response: 0x122
+          value: "SG3K-D"
+        - response: 0x0126
+          value: "SG5K-D"
+        - response: 0x2403
+          value: "SG8K-D"
+      # RS Series
+        - response: 0x2603
+          value: "SG3.0RS"
+        - response: 0x2604
+          value: "SG3.6RS"
+        - response: 0x2605
+          value: "SG4.0RS"
+        - response: 0x2606
+          value: "SG5.0RS"
+        - response: 0x2607
+          value: "SG6.0RS"
+        - response: 0x260E
+          value: "SG9.0RS"
+        - response: 0x2609
+          value: "SG10RS"
+    - name: "nominal_active_power"   
+      level: 2
+      address: 5001
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kW"
+    - name: "output_type"
+      level: 2
+      address: 5002
+      datatype: "U16"
+      datarange:
+        - response: 0
+          value: "2P"
+        - response: 1
+          value: "3P4L"
+        - response: 2
+          value: "3PSL"
+    - name: "daily_power_yields"    
+      level: 0
+      address: 5003
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+    - name: "total_power_yields"  
+      level: 1  
+      address: 5004
+      datatype: "U32"
+      unit: "kWh"
+    - name: "total_running_time"  
+      level: 1  
+      address: 5006
+      datatype: "U32"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+      unit: "h"
+    - name: "internal_temperature"
+      level: 1    
+      address: 5008
+      datatype: "S16"
+      accuracy: 0.1
+      unit: "°C"
+    - name: "total_apparent_power"
+      level: 1    
+      address: 5009
+      datatype: "U32"
+      models: ["SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG33K3J","SG36KTL-M","SG40KTL-M","SG50KTL","SG50KTL-M","SG60KTL","SG60KTL-M","SG60KU-M","SG80KTL","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG33CX","SG40CX","SG50CX","SG110CX","SG250HX","SG30CX","SG36CX-US","SG60CX-US","SG250HX-US","SG250HX-IN","SG25CX-SA","SG100CX","SG75CX","SG225HX"]
+      unit: "VA"
+    - name: "mppt_1_voltage"    
+      level: 2
+      address: 5011
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+    - name: "mppt_1_current" 
+      level: 2   
+      address: 5012
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+    - name: "mppt_2_voltage" 
+      level: 2   
+      address: 5013
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "mppt_2_current"
+      level: 2    
+      address: 5014
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "mppt_3_voltage"
+      level: 2    
+      address: 5015
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG50KTL-M-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX"]
+    - name: "mppt_3_current"
+      level: 2    
+      address: 5016
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG50KTL-M-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG8K-D"]
+    - name: "total_dc_power"
+      level: 2    
+      address: 5017
+      datatype: "U32" # Documentation says Unsigned, but seems to be returning Signed 32bit
+      unit: "W"
+    - name: "phase_a_voltage"
+      level: 1
+      address: 5019
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+    - name: "phase_b_voltage"
+      level: 2    
+      address: 5020
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+    - name: "phase_c_voltage"
+      level: 2    
+      address: 5021
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+    - name: "phase_a_current"
+      level: 2    
+      address: 5022
+      datatype: "S16" # Documentation says Unsigned, but seems to be returning Signed 16bit
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+    - name: "phase_b_current" 
+      level: 2   
+      address: 5023
+      datatype: "S16" # Documentation says Unsigned, but seems to be returning Signed 16bit
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+    - name: "phase_c_current"
+      level: 2    
+      address: 5024
+      datatype: "S16" # Documentation says Unsigned, but seems to be returning Signed 16bit
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+#   - name: "Reserved"    
+#     address: 5025
+#     datatype: "U32"
+#   - name: "Reserved"    
+#     address: 5027
+#     datatype: "U32"
+#   - name: "Reserved"    
+#     address: 5029
+#     datatype: "U32"
+    - name: "total_active_power"
+      level: 0    
+      address: 5031
+      datatype: "U32"
+      unit: "W"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "total_reactive_power"
+      level: 2    
+      address: 5033
+      datatype: "S32"
+      unit: "Var"
+    - name: "power_factor"                # >0 means leading, <0 means lagging
+      level: 2
+      address: 5035
+      datatype: "S16"
+      accuracy: 0.001
+    - name: "grid_frequency"
+      level: 2    
+      address: 5036
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "Hz"
+#   - name: "Reserved"    
+#     address: 5037
+#     datatype: "U16"
+    - name: "work_state_1"                # See Appendix 1
+      level: 1
+      address: 5038
+      datatype: "U16"
+      datarange:
+        - response: 0x0
+          value: "Run"
+        - response: 0x8000
+          value: "Stop"
+        - response: 0x1300
+          value: "Key Stop"
+        - response: 0x1500
+          value: "Emergency Stop"
+        - response: 0x1400
+          value: "Standby"
+        - response: 0x1200
+          value: "Initial Standby"
+        - response: 0x1600
+          value: "Starting"
+        - response: 0x9100
+          value: "Alarm Run"
+        - response: 0x8100
+          value: "Derating Run"
+        - response: 0x8200
+          value: "Dispatch Run"
+        - response: 0x5500
+          value: "Fault"
+        - response: 0x2500
+          value: "Communication Fault"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "alarm_time_year"
+      level: 3
+      address: 5039
+      datatype: "U16"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "alarm_time_month" 
+      level: 3   
+      address: 5040
+      datatype: "U16"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "alarm_time_day"  
+      level: 3
+      address: 5041
+      datatype: "U16"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "alarm_time_hour"
+      level: 3
+      address: 5042
+      datatype: "U16"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "alarm_time_minute" 
+      level: 3   
+      address: 5043
+      datatype: "U16"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "alarm_time_second"
+      level: 3
+      address: 5045
+      datatype: "U16"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "alarm_code_1"               # See Appendix 3
+      level: 3
+      address: 5045
+      datatype: "U16" 
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+#   - name: "Reserved"    
+#     address: 5046 - 5048
+#     datatype: "U16"
+#     models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "nominal_reactive_power"
+      level: 2
+      address: 5049
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kVar"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+#   - name: "Reserved"    
+#     address: 5050 - 5070
+#     datatype: "U32"
+    - name: "array_insulation_resistance" 
+      level: 2   
+      address: 5071
+      datatype: "U16"
+      unit: "k-ohm"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+#   - name: "Reserved"    
+#     address: 5072
+#     datatype: "U16"
+#   - name: "Reserved"    
+#     address: 5073 - 5076
+    - name: "active_power_regulation_setpoint"   
+      level: 2 
+      address: 5077
+      datatype: "U32"
+      unit: "W"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "reactive_power_regulation_setpoint"    
+      level: 2
+      address: 5079
+      datatype: "S32"
+      unit: "Var"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+    - name: "work_state_2"                # See Appendix 2
+      level: 2
+      address: 5081
+      datatype: "U32"
+      datarange:
+        - response: 0
+          value: "Run"
+        - response: 1
+          value: "Stop"
+        - response: 3
+          value: "Key Stop"
+        - response: 5
+          value: "Emergency Stop"
+        - response: 4
+          value: "Standby"
+        - response: 2
+          value: "Initial Standby"
+        - response: 6
+          value: "Starting"
+        - response: 10
+          value: "Alarm Run"
+        - response: 11
+          value: "Derating Run"
+        - response: 12
+          value: "Dispatch Run"
+        - response: 9
+          value: "Fault"
+        - response: 13
+          value: "Communication Fault"
+        - response: 17
+          value: "Total Run Bit"
+        - response: 18
+          value: "Total Fault Bit"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "meter_power" 
+      level: 1
+      address: 5083
+      datatype: "S32"
+      smart_meter: True
+      unit: "W"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "meter_a_phase_power"
+      level: 2
+      address: 5085
+      datatype: "S32"
+      unit: "W"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "meter_b_phase_power"
+      level: 2
+      address: 5087
+      datatype: "S32"
+      unit: "W"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "meter_c_phase_power"
+      level: 2
+      address: 5089
+      datatype: "S32"
+      unit: "W"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "load_power"
+      level: 1
+      address: 5091
+      datatype: "S32"
+      smart_meter: True
+      unit: "W"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "daily_export_energy"
+      level: 1
+      address: 5093
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "total_export_energy"
+      level: 1
+      address: 5095
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "daily_import_energy"
+      level: 1
+      address: 5097
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "total_import_energy"
+      level: 1
+      address: 5099
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "daily_direct_energy_consumption"
+      level: 1
+      address: 5101
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "total_direct_energy_consumption"
+      level: 1
+      address: 5103
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3K-D","SG5K-D","SG8K-D"]
+#   - name: "Reserved"    
+#     address: 5105 - 5112
+    - name: "daily_running_time"
+      level: 1
+      address: 5113
+      datatype: "U16"
+      unit: "min"
+    - name: "mppt_4_voltage"    
+      level: 2
+      address: 5115
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG50KTL-M","SG60KTL-M","SG49K5J","SG50KTL-M-20","SG60KU-M","SG80KTL-M","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_4_current"    
+      level: 2
+      address: 5116
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG50KTL-M","SG60KTL-M","SG49K5J","SG50KTL-M-20","SG60KU-M","SG80KTL-M","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_5_voltage" 
+      level: 2   
+      address: 5117
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_5_current"  
+      level: 2  
+      address: 5118
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_6_voltage"   
+      level: 2 
+      address: 5119
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_6_current"   
+      level: 2 
+      address: 5120
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_7_voltage"    
+      level: 2
+      address: 5121
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_7_current"    
+      level: 2
+      address: 5122
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_8_voltage"    
+      level: 2
+      address: 5123
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_8_current"    
+      level: 2
+      address: 5124
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+#   - name: "Reserved"    
+#     address: 5125
+#   - name: "Reserved"    
+#     address: 5126 - 5127
+    - name: "monthly_power_yields"    
+      level: 1
+      address: 5128
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+    - name: "mppt_9_voltage"    
+      level: 2
+      address: 5130
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_9_current"    
+      level: 2
+      address: 5131
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "mppt_10_voltage"    
+      level: 2
+      address: 5132
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+    - name: "mppt_10_current"    
+      level: 2
+      address: 5133
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+    - name: "mppt_11_voltage"    
+      level: 2
+      address: 5134
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+    - name: "mppt_11_current"    
+      level: 2
+      address: 5135
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+    - name: "mppt_12_voltage"    
+      level: 2
+      address: 5136
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+    - name: "mppt_12_current"    
+      level: 2
+      address: 5137
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+#   - name: "Reserved"    
+#     address: 5138 - 5139
+#   - name: "Reserved"    
+#     address: 5140
+#   - name: "Reserved"    
+#     address: 5141
+#   - name: "Reserved"    
+#     address: 5142
+#   - name: "Reserved"    
+#     address: 5143
+    - name: "total_power_yields"    
+      level: 1
+      address: 5144
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG33CX","SG40CX","SG50CX","SG110CX","SG250HX","SG30CX","SG36CX-US","SG60CX-US","SG250HX-US","SG250HX-IN","SG25CX-SA","SG100CX","SG75CX","SG225HX","SG3K-D","SG5K-D","SG8K-D"]
+    - name: "negative_voltage_to_the_ground"   
+      level: 2 
+      address: 5146
+      datatype: "S16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+    - name: "bus_voltage"    
+      level: 2
+      address: 5147
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+    - name: "grid_frequency"    
+      level: 2
+      address: 5148
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "Hz"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG33CX","SG40CX","SG50CX","SG110CX","SG250HX","SG30CX","SG36CX-US","SG60CX-US","SG250HX-US","SG250HX-IN","SG25CX-SA","SG100CX","SG75CX","SG225HX","SG3K-D","SG5K-D","SG8K-D"]
+#   - name: "Reserved"    
+#     address: 5149
+#     datatype: "U16"
+#     accuracy: 0.01
+    - name: "pid_work_state"
+      level: 2
+      address: 5150
+      datatype: "U16"
+      datarange:
+        - response: 2
+          value: "PID Recover Operation"
+        - response: 4
+          value: "Anti-PID Operation"
+        - response: 8
+          value: "PID Abnormity"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG33CX","SG40CX","SG50CX","SG110CX","SG250HX","SG30CX","SG36CX-US","SG60CX-US","SG250HX-US","SG250HX-IN","SG25CX-SA","SG100CX","SG75CX","SG225HX"]
+    - name: "pid_alarm_code"
+      level: 2
+      address: 5151
+      datatype: "U16"
+      datarange:
+        - response: 432
+          value: "PID resistance abnormal"
+        - response: 433
+          value: "PID function abnormal"
+        - response: 434
+          value: "PID overvoltage/overcurrent protection"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+#   - name: "Reserved"    
+#     address: 5152
+#     datatype: "U16"
+    # Following 2 registers are not in the documentation, but other projects are using them
+    - name: "export_power"
+      level: 2
+      address: 5216
+      datatype: "S32"
+      unit: "W"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+    - name: "power_meter" 
+      level: 2   
+      address: 5218
+      datatype: "S32"
+      unit: "W"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+#   - name: "Reserved"    
+#     address: 5153-7012
+##### Residential Hybrid Inverters only START
+    - name: "meter_total_power"
+      level: 2
+      address: 5601
+      datatype: "S32"
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS", "SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112","SG8.0RT"]
+    - name: "meter_phase_a_power"
+      level: 2
+      address: 5603
+      datatype: "S32"
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112","SG8.0RT"]
+    - name: "meter_phase_b_power"
+      level: 2
+      address: 5605
+      datatype: "S32"
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112","SG8.0RT"]
+    - name: "meter_phase_c_power"
+      level: 2
+      address: 5607
+      datatype: "S32"
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112","SG8.0RT"]
+    - name: "export_limit_min"
+      level: 2
+      address: 5622
+      datatype: "U16"
+      accuracy: 10
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "export_limit_max"
+      level: 2
+      address: 5623
+      datatype: "U16"
+      accuracy: 10
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bdc_rated_power"
+      level: 2
+      address: 5628
+      datatype: "U16"
+      accuracy: 100
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bms_max_charging_current"
+      level: 2
+      address: 5635
+      datatype: "U16"
+      unit: "A"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bms_max_discharging_current"
+      level: 2
+      address: 5636
+      datatype: "U16"
+      unit: "A"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "backup_phase_a_power"
+      level: 2
+      address: 5723
+      datatype: "S16"
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "backup_phase_b_power"
+      level: 2
+      address: 5724
+      datatype: "S16"
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "backup_phase_c_power"
+      level: 2
+      address: 5725
+      datatype: "S16"
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "total_backup_power"
+      level: 2
+      address: 5726
+      datatype: "S16"
+      unit: "W"
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "pv_power_of_today"
+      level: 1
+      address: 6100
+      datatype: "U16"
+      unit: "W"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "daily_pv_energy_yields"    
+      level: 1
+      address: 6196
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "monthly_pv_energy_yields"    
+      level: 2
+      address: 6227
+      datatype: "U16"
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "yearly_pv_energy_yields"    
+      level: 2
+      address: 6250
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "direct_power_consumption_today_pv"    
+      level: 1
+      address: 6290
+      datatype: "U16"
+      unit: "W"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "direct_power_consumption_pv"    
+      level: 1
+      address: 6386
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "direct_power_consumption_monthly_pv"    
+      level: 2
+      address: 6417
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "direct_power_consumption_yearly_pv"    
+      level: 2
+      address: 6429
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "export_power_from_pv_today"    
+      level: 1
+      address: 6469
+      datatype: "U16"
+      unit: "W"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "export_power_from_pv"    
+      level: 1
+      address: 6565
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "export_power_from_pv_monthly"    
+      level: 2
+      address: 6596
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "export_power_from_pv_yearly"    
+      level: 2
+      address: 6608
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "battery_charge_power_from_pv_today"    
+      level: 1
+      address: 6648
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "battery_charge_power_from_pv"    
+      level: 1
+      address: 6744
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "battery_charge_power_from_pv_monthly"    
+      level: 2
+      address: 6775
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "battery_charge_power_from_pv_yearly"    
+      level: 2
+      address: 6787
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+ ##### Residential Hybrid Inverters only END
+    - name: "string_1_current"    
+      level: 2
+      address: 7013
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+    - name: "string_2_current"    
+      level: 2
+      address: 7014
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+    - name: "string_3_current"    
+      level: 2
+      address: 7015
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT", ]
+    - name: "string_4_current"    
+      level: 2
+      address: 7016
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX", ]
+    - name: "string_5_current"    
+      level: 2
+      address: 7017
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX", ]
+    - name: "string_6_current"    
+      level: 2
+      address: 7018
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX", ]
+    - name: "string_7_current"    
+      level: 2
+      address: 7019
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG30KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
+    - name: "string_8_current"    
+      level: 2
+      address: 7020
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG30KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
+    - name: "string_9_current"    
+      level: 2
+      address: 7021
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG30KU","SG36KTL","SG36KU","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG33K3J","SG49K5J","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
+    - name: "string_10_current"    
+      level: 2
+      address: 7022
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG30KU","SG36KTL","SG36KU","SG50KTL-M","SG60KTL-M","SG49K5J","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
+    - name: "string_11_current"    
+      level: 2
+      address: 7023
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG50KTL-M","SG60KTL-M","SG49K5J","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
+    - name: "string_12_current"    
+      level: 2
+      address: 7024
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG50KTL-M","SG60KTL-M","SG49K5J","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
+    - name: "string_13_current"    
+      level: 2
+      address: 7025
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG60KTL-M","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
+    - name: "string_14_current"    
+      level: 2
+      address: 7026
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG60KTL-M","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT", ]
+    - name: "string_15_current"    
+      level: 2
+      address: 7027
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG60KTL-M","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "string_16_current"    
+      level: 2
+      address: 7028
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG60KTL-M","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "string_17_current"    
+      level: 2
+      address: 7029
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG80KTL","SG80KTL-20","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "string_18_current"    
+      level: 2
+      address: 7030
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG80KTL","SG80KTL-20","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
+    - name: "string_19_current"    
+      level: 2
+      address: 7031
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+    - name: "string_20_current"    
+      level: 2
+      address: 7032
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+    - name: "string_21_current"    
+      level: 2
+      address: 7033
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+    - name: "string_22_current"    
+      level: 2
+      address: 7034
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+    - name: "string_23_current"    
+      level: 2
+      address: 7035
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+    - name: "string_24_current"    
+      level: 2
+      address: 7036
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "A"
+      models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
+  ##### Residential Hybrid Inverters only START
+    - name: "system_state"    
+      level: 2
+      address: 13000
+      datatype: "U16"
+      datarange:
+        - response: 0x0002
+          value: "Stop"
+        - response: 0x0008
+          value: "Standby"
+        - response: 0x0010
+          value: "Initial Standby"
+        - response: 0x0020
+          value: "Startup"
+        - response: 0x0040
+          value: "Run"
+        - response: 0x0100
+          value: "Fault"
+        - response: 0x0400
+          value: "Maintain Run"
+        - response: 0x0800
+          value: "Forced Run"
+        - response: 0x1000
+          value: "Off-grid Run"
+        - response: 0x2501
+          value: "Restarting"
+        - response: 0x4000
+          value: "EMS Run"
+      default: "Unknown"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "running_state"
+      level: 2
+      address: 13001
+      datatype: "U16"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "state_power_generated_from_pv"
+      level: 2
+      address: 13001
+      datatype: "U16"
+      mask: 1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "state_battery_charging"
+      level: 2
+      address: 13001
+      datatype: "U16"
+      mask: 2
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "state_battery_discharging"
+      level: 2
+      address: 13001
+      datatype: "U16"
+      mask: 4
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "state_load_active"
+      level: 2
+      address: 13001
+      datatype: "U16"
+      mask: 8
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "state_feed_into_grid"
+      level: 2
+      address: 13001
+      datatype: "U16"
+      mask: 16
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "state_import_from_grid"
+      level: 2
+      address: 13001
+      datatype: "U16"
+      mask: 32
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "state_power_generated_from_load"
+      level: 2
+      address: 13001
+      datatype: "U16"
+      mask: 128
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "daily_pv_generation"
+      level: 2
+      address: 13002
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "total_pv_generation"    
+      level: 1
+      address: 13003
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "daily_pv_export"    
+      level: 1
+      address: 13005
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "total_pv_export"    
+      level: 1
+      address: 13006
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "load_power_hybrid"    
+      level: 1
+      address: 13008
+      datatype: "S32"
+      unit: "W"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "export_power_hybrid"    
+      level: 1
+      address: 13010
+      datatype: "S32"
+      unit: "W"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "daily_battery_charge_from_pv"
+      level: 1
+      address: 13012
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "total_battery_charge_from_pv"    
+      level: 1
+      address: 13013
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "co2_reduction"    
+      level: 2
+      address: 13015
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kg"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "daily_direct_energy_consumption"    
+      level: 1
+      address: 13017
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "total_direct_energy_consumption"    
+      level: 1
+      address: 13018
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"] 
+    - name: "battery_voltage"    
+      level: 2
+      address: 13020
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "V"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "battery_current"    
+      level: 2
+      address: 13021
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "battery_power"    
+      level: 1
+      address: 13022
+      datatype: "S16"
+      unit: "W"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "battery_level"    
+      level: 1
+      address: 13023
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "%"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "battery_state_of_healthy"    
+      level: 2
+      address: 13024
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "%"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "battery_temperature"    
+      level: 2
+      address: 13025
+      datatype: "S16"
+      accuracy: 0.1
+      unit: "°C"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "daily_battery_discharge_energy"    
+      level: 2
+      address: 13026
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "total_battery_discharge_energy"    
+      level: 2
+      address: 13027
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "self_consumption_of_day"    
+      level: 1
+      address: 13029
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "%"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "grid_state"    
+      level: 1
+      address: 13030
+      datatype: "U16"
+      datarange:
+        - response: 0xAA
+          value: "Off-grid"
+        - response: 0x55
+          value: "On-grid"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "phase_a_current"    
+      level: 2
+      address: 13031
+      datatype: "S16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "phase_b_current"    
+      level: 2
+      address: 13032
+      datatype: "S16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "phase_c_current"    
+      level: 2
+      address: 13033
+      datatype: "S16"
+      accuracy: 0.1
+      unit: "A"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "total_active_power"    
+      level: 0
+      address: 13034
+      datatype: "S32"
+      unit: "W"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "daily_import_energy"    
+      level: 1
+      address: 13036
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "total_import_energy"    
+      level: 1
+      address: 13037
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "battery_capacity"    
+      level: 1
+      address: 13039
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "daily_charge_energy"    
+      level: 2
+      address: 13040
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "total_charge_energy"    
+      level: 2
+      address: 13041
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "drm_state"    
+      level: 2
+      address: 13043
+      datatype: "U16"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "daily_export_energy"    
+      level: 1
+      address: 13045
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "total_export_energy"    
+      level: 2
+      address: 13046
+      datatype: "U32"
+      accuracy: 0.1
+      unit: "kWh"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "inverter_alarm"
+      level: 3
+      address: 13050
+      datatype: "U32"
+      accuracy: 0.1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "grid-side_fault"
+      level: 3
+      address: 13052
+      datatype: "U32"
+      accuracy: 0.1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "system_fault1"
+      level: 3
+      address: 13054
+      datatype: "U32"
+      accuracy: 0.1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "system_fault2"
+      level: 3
+      address: 13056
+      datatype: "U32"
+      accuracy: 0.1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "dc-side_fault"
+      level: 3
+      address: 13058
+      datatype: "U32"
+      accuracy: 0.1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "permanent_fault"
+      level: 3
+      address: 13060
+      datatype: "U32"
+      accuracy: 0.1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bdc-side_fault"
+      level: 3
+      address: 13062
+      datatype: "U32"
+      accuracy: 0.1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bdc-side_permanent_fault"
+      level: 3
+      address: 13064
+      datatype: "U32"
+      accuracy: 0.1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "battery_fault"
+      level: 3
+      address: 13066
+      datatype: "U32"
+      accuracy: 0.1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "battery_alarm"
+      level: 3
+      address: 13068
+      datatype: "U32"
+      accuracy: 0.1
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bms_alarm"
+      level: 3
+      address: 13070
+      datatype: "U32"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bms_protection"
+      level: 3
+      address: 13072
+      datatype: "U32"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bms_fault1"
+      level: 3
+      address: 13074
+      datatype: "U32"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bms_fault2"
+      level: 3
+      address: 13076
+      datatype: "U32"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bms_alarm2"
+      level: 3
+      address: 13078
+      datatype: "U32"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "bms_status"
+      level: 3
+      address: 13100
+      datatype: "U16"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "max_charging_current"
+      level: 3
+      address: 13101
+      datatype: "U16"
+      unit: "A"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "max_discharging_current"
+      level: 3
+      address: 13102
+      datatype: "U16"
+      unit: "A"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "warning"
+      level: 3
+      address: 13103
+      datatype: "U16"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "protection"
+      level: 3
+      address: 13104
+      datatype: "U16"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "fault1"
+      level: 3
+      address: 13105
+      datatype: "U16"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "fault2"
+      level: 3
+      address: 13106
+      datatype: "U16"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "soc"
+      level: 2
+      address: 13107
+      datatype: "U16"
+      unit: "%"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "soh"
+      level: 2
+      address: 13108
+      datatype: "U16"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "battery_current"
+      level: 2
+      address: 13109
+      datatype: "U16"
+      unit: "A"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "battery_voltage"
+      level: 2
+      address: 13110
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "V"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "cycle_count"
+      level: 2
+      address: 13111
+      datatype: "U16"
+      accuracy: 0.01
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "average_cell_voltage"
+      level: 2
+      address: 13112
+      datatype: "U16"
+      unit: "V"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "max_cell_voltage"
+      level: 2
+      address: 13113
+      datatype: "U16"
+      unit: "V"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "min_cell_voltage"
+      level: 2
+      address: 13114
+      datatype: "U16"
+      unit: "V"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "battery_pack_voltage"
+      level: 2
+      address: 13115
+      datatype: "U16"
+      unit: "V"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "average_cell_temp"
+      level: 2
+      address: 13116
+      datatype: "S16"
+      unit: "°C"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "max_cell_temp"
+      level: 2
+      address: 13117
+      datatype: "S16"
+      unit: "°C"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+    - name: "min_cell_temp"
+      level: 2
+      address: 13118
+      datatype: "S16"
+      unit: "°C"
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
+ ##### Residential Hybrid Inverters only END
+  - hold:
+    - name: "year"
+      level: 0
+      address: 5000
+      datatype: "U16"
+      unit: "YYYY"
+    - name: "month"
+      level: 0
+      address: 5001
+      datatype: "U16"
+      unit: "MM"
+    - name: "day"
+      level: 0
+      address: 5002
+      datatype: "U16"
+      unit: "DD"
+    - name: "hour"
+      level: 0
+      address: 5003
+      datatype: "U16"
+      unit: "HH"
+    - name: "minute"
+      level: 0
+      address: 5004
+      datatype: "U16"
+      unit: "MM"
+    - name: "second"
+      level: 0
+      address: 5005
+      datatype: "U16"
+      unit: "SS"
+    - name: "start_stop"
+      level: 1
+      address: 5006
+      datatype: "U16"
+      datarange:
+        - response: 0xCF
+          value: "Start"
+        - response: 0xCE
+          value: "Stop"
+    - name: "power_limitation_switch"
+      level: 2
+      address: 5007
+      datatype: "U16"
+      datarange:
+        - response: 0xAA
+          value: "Enable"
+        - response: 0x55
+          value: "Disable"
+    - name: "power_limitation_setting"
+      level: 2
+      address: 5008
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "%"
+#   - name: "Reserved"    
+#     address: 5009
+#     datatype: "U16"
+#     models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "export_power_limitation"
+      level: 2
+      address: 5010
+      datatype: "U16"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+      datarange:
+        - response: 0xAA
+          value: "Enable"
+        - response: 0x55
+          value: "Disable"
+    - name: "export_power_limitation_value"
+      level: 2
+      address: 5011
+      datatype: "U16"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "current_transformer_output_current"
+      level: 2
+      address: 5012
+      datatype: "U16"
+      unit: "A"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "current_transformer_range"
+      level: 2
+      address: 5013
+      datatype: "U16"
+      unit: "A"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "current_transformer"
+      level: 2
+      address: 5014
+      datatype: "U16"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+      datarange:
+        - response: 0
+          value: "Internal"
+        - response: 1
+          value: "External"
+    - name: "export_power_limitation_percentage"
+      level: 2
+      address: 5015
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "%"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "installed_pv_power"
+      level: 2
+      address: 5016
+      datatype: "U16"
+      accuracy: 0.01
+      unit: "KW"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
+    - name: "power_factor_setting"
+      level: 2
+      address: 5019
+      datatype: "U16"
+      accuracy: 0.001
+    - name: "scheduling_achieve_active_overload"
+      level: 2
+      address: 5020
+      datatype: "U16"
+      models: ["SG33CX","SG40CX","SG50CX","SG75CX","SG110CX","SG136TX","SG250HX","SG30CX","SG36CX-US","SG60CX-US","SG250HX-US","SG250HX-IN","SG225HX","SG250HX","SG25CX-SA","SG100CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+      datarange:
+        - response: 0xAA
+          value: "Enable"
+        - response: 0x55
+          value: "Disable"
+#   - name: "Reserved"    
+#     address: 5021-5033
+#     datatype: "U16"
+    - name: "night_svg_switch"
+      level: 2
+      address: 5035
+      datatype: "U16"
+      models: ["SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG80KTL-M","SG125HV-20","SG33CX","SG40CX","SG50CX","SG110CX","SG136TX","SG250HX","SG30CX","SG36CX-US","SG60CX-US","SG250HX-US","SG250HX-IN","SG225HX","SG250HX","SG25CX-SA","SG100CX","SG75CX"]
+      datarange:
+        - response: 0xAA
+          value: "Enable"
+        - response: 0x55
+          value: "Disable"
+    - name: "reactive_power_adjustment_mode"
+      level: 2
+      address: 5036
+      datatype: "U16"
+      datarange:
+        - response: 0x55
+          value: "Off"
+        - response: 0xA1
+          value: "Power factor setting"
+        - response: 0xA2
+          value: "Reactive power percentage setting"
+        - response: 0xA3
+          value: "Enable Q(P)"
+        - response: 0xA4
+          value: "Enable Q(U)"
+    - name: "reactive_power_percentage_setting"
+      level: 2
+      address: 5037
+      datatype: "S16"
+      accuracy: 0.1
+      unit: "%"
+#   - name: "Reserved"    
+#     address: 5038
+    - name: "power_limitation_adjustment"
+      level: 2
+      address: 5039
+      datatype: "U16"
+      accuracy: 0.1
+      unit: "kW"
+    - name: "reactive_power_adjustment"
+      level: 2
+      address: 5040
+      datatype: "S16"
+      accuracy: 0.1
+      unit: "kVar"
+    - name: "pid_recovery"
+      level: 2
+      address: 5041
+      datatype: "U16"
+      models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG80KTL-M","SG125HV","SG125HV-20","SG80KTL","SG33CX","SG40CX","SG50CX","SG100CX、SG75CX","SG110CX","SG136TX","SG250HX","SG30CX","SG36CX-US","SG60CX-US","SG250HX-US","SG250HX-IN","SG25CX-SA","SG225HX"]
+      datarange:
+        - response: 0xAA
+          value: "Enable"
+        - response: 0x55
+          value: "Disable"
+    - name: "anti_pid"
+      level: 2
+      address: 5042
+      datatype: "U16"
+      models: ["SG125HV","SG125HV-20","SG250HX","SG250HX-US","SG250HX-IN","SG136TX","SG100CX-JP","SG225HX"]
+      datarange:
+        - response: 0xAA
+          value: "Enable"
+        - response: 0x55
+          value: "Disable"
+    - name: "fullday_pid_suppression"
+      level: 2
+      address: 5043
+      datatype: "U16"
+      models: ["SG250HX","SG250HX-US","SG250HX-IN","SG225HX"]
+      datarange:
+        - response: 0xAA
+          value: "Enable"
+        - response: 0x55
+          value: "Disable"
+#   - name: "Reserved"    
+#     address: 5043-5047
+#   - name: "Q(P) Curve"    
+#     address: 5048-5154
+#   - name: "Reserved"    
+#     address: 5155-5199
+  ## Undocumented see: https://github.com/bohdan-s/SunGather/pull/114
+    - name: "ems_mode_selection"
+      address: 13050
+      level: 2
+      datatype: "U16"
+      datarange:
+        - response: 0
+          value: "Self-consumption mode"
+        - response: 2
+          value: "Compulsory mode"
+        - response: 3
+          value: "External EMS mode"
+      models: ["SH5K-20", "SH3K6", "SH4K6", "SH5K-V13", "SH5K-30", "SH3K6-30", "SH4K6-30", "SH3.6RS", "SH5.0RS", "SH4.6RS", "SH6.0RS", "SH5.0RT", "SH5.0RT-V112", "SH6.0RT", "SH8.0RT", "SH10RT", "SH10RT-V112"]
+    - name: "charge_discharge_command"
+      address: 13051
+      level: 2
+      datatype: "U16"
+      datarange:
+        - response: 0xAA
+          value: "Charge"
+        - response: 0xBB
+          value: "Discharge"
+        - response: 0xCC
+          value: "Stop"
+      models: ["SH5K-20", "SH3K6", "SH4K6", "SH5K-V13", "SH5K-30", "SH3K6-30", "SH4K6-30", "SH3.6RS", "SH5.0RS", "SH4.6RS", "SH6.0RS", "SH5.0RT", "SH5.0RT-V112", "SH6.0RT", "SH8.0RT", "SH10RT", "SH10RT-V112"]
+    - name: charge_discharge_power
+      address: 13052
+      level: 2
+      accuracy: 1
+      datatype: "U16"
+      unit: "W"
+      models: ["SH5K-20", "SH3K6", "SH4K6", "SH5K-V13", "SH5K-30", "SH3K6-30", "SH4K6-30", "SH3.6RS", "SH5.0RS", "SH4.6RS", "SH6.0RS", "SH5.0RT", "SH5.0RT-V112", "SH6.0RT", "SH8.0RT", "SH10RT", "SH10RT-V112"]
+    - name: "start_charging_power"
+      address: 13084
+      level: 2
+      accuracy: 10
+      datatype: "U16"
+      unit: "W"
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "start_discharging_power"
+      address: 13085
+      level: 2
+      accuracy: 10
+      datatype: "U16"
+      unit: "W"
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "energy_meter_comm"
+      address: 13086
+      level: 2
+      datatype: "U16"
+      datarange:
+        - response: 0xAA
+          value: "Enabled"
+        - response: 0x55
+          value: "Disabled"
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "export_power_limitation"
+      address: 13087
+      level: 2
+      datatype: "U16"
+      datarange:
+        - response: 0xAA
+          value: "Enabled"
+        - response: 0x55
+          value: "Disabled"
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "soc_reserve"
+      address: 13100
+      level: 2
+      datatype: "U16"
+      unit: "%"
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+  ## Undocumented see: https://github.com/bohdan-s/SunGather/pull/103
+    - name: "battery_max_charge_power"
+      address: 33047
+      level: 2
+      accuracy: 10
+      datatype: "U16"
+      unit: "W"
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+    - name: "battery_max_discharge_power"
+      address: 33048
+      level: 2
+      accuracy: 10
+      datatype: "U16"
+      unit: "W"
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
+scan: # these have to be 1 less than the first register
+  - read:
+    - start: 4949
+      range: 50
+    - start: 5000 # We don't start at 4999 because we read register 5000 once manually, not every scan
+      range: 38   # we do 38/61 instead of 100 to work around an issue with SH5.0RS, WiNet-S. This will make no noticeable difference to scan times.
+    - start: 5039
+      range: 61
+    - start: 5100
+      range: 100
+    - start: 5200
+      range: 100
+    - start: 5600
+      range: 100
+    - start: 5720
+      range: 10
+    - start: 6099
+      range: 100
+    - start: 6199
+      range: 100
+    - start: 6299
+      range: 100
+    - start: 6399
+      range: 100
+    - start: 6499
+      range: 100
+    - start: 6599
+      range: 100
+    - start: 6699
+      range: 100
+    - start: 6799
+      range: 100
+    - start: 7012
+      range: 25
+    - start: 12999
+      range: 125
+  - hold:
+    - start: 4999
+      range: 10
+    - start: 5009
+      range: 10
+    - start: 5034
+      range: 10
+    - start: 13000
+      range: 100
+    - start: 33045
+      range: 5
+# Models Supported:
+# PV      ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG3.0RS","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
+# Hybrid  ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]


### PR DESCRIPTION
Updated following registers to include "SG8.0RT" as a supported model.

##### Residential Hybrid Inverters only START
    - name: "meter_total_power"
      level: 2
      address: 5601
      datatype: "S32"
      unit: "W"
      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
    - name: "meter_phase_a_power"
      level: 2
      address: 5603
      datatype: "S32"
      unit: "W"
      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
    - name: "meter_phase_b_power"
      level: 2
      address: 5605
      datatype: "S32"
      unit: "W"
      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]
    - name: "meter_phase_c_power"
      level: 2
      address: 5607
      datatype: "S32"
      unit: "W"
      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]```